### PR TITLE
Update hugo version automatically with renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,10 @@
+{
+  "regexManagers": [
+    {
+      "fileMatch": ["^netlify.toml$"],
+      "matchStrings": ["HUGO_VERSION = \"(?<currentValue>.*?)\"\n"],
+      "depNameTemplate": "gohugoio/hugo",
+      "datasourceTemplate": "github-releases"
+    }
+  ]
+}


### PR DESCRIPTION
Close: #25 

以下、自分が持ってる別の repository ですが、この config で PR が作られました。
- commit https://github.com/chaspy/weekendersfm/commit/2d57d6dbc082ab369325c271db03763f540102bb
- PR https://github.com/chaspy/weekendersfm/pull/33

Renovate の Regex Manager に関するドキュメント: https://docs.renovatebot.com/modules/manager/regex/